### PR TITLE
Fix/remove context for validations

### DIFF
--- a/lib/schema_dot_org.rb
+++ b/lib/schema_dot_org.rb
@@ -98,7 +98,7 @@ module SchemaDotOrg
 
 
     def attrs
-      instance_variables.reject{ |v| [:@validation_context, :@errors].include?(v) }
+      instance_variables.reject{ |v| %i[@context_for_validation@validation_context @errors].include?(v) }
     end
 
 

--- a/lib/schema_dot_org.rb
+++ b/lib/schema_dot_org.rb
@@ -98,7 +98,7 @@ module SchemaDotOrg
 
 
     def attrs
-      instance_variables.reject{ |v| %i[@context_for_validation@validation_context @errors].include?(v) }
+      instance_variables.reject{ |v| [:@context_for_validation, :@validation_context, :@errors].include?(v) }
     end
 
 


### PR DESCRIPTION
Remove unwanted `contextForValidation` attribute from the `attrs` hash.