### PR TITLE
[Feature] @graph ability

### DIFF
--- a/lib/graph_container.rb
+++ b/lib/graph_container.rb
@@ -1,0 +1,31 @@
+module SchemaDotOrg
+  class GraphContainer  
+    def initialize(*schema_objects)
+      @schema_objects = schema_objects.flatten
+    end
+  
+    def to_s
+      to_json_ld
+    end
+  
+    def to_json_ld(pretty: false)
+      "<script type=\"application/ld+json\">\n" + to_json(pretty: pretty) + "\n</script>"
+    end
+  
+    def to_json(pretty: false)
+      structure = { 
+        "@context" => "https://schema.org", 
+        "@graph" => @schema_objects.map(&:to_json_struct),
+      }
+
+      structure["@id"] = @id if @id
+
+      if pretty
+        JSON.pretty_generate(structure)
+      else
+        structure.to_json
+      end
+    end
+  end
+end
+

--- a/lib/schema_dot_org.rb
+++ b/lib/schema_dot_org.rb
@@ -3,9 +3,6 @@ require 'json'
 require 'validated_object'
 require 'graph_container'
 
-#
-# Abstract base class for all the Schema.org types.
-#
 module SchemaDotOrg
 
   def self.create_graph(*schema_objects)


### PR DESCRIPTION
This PR adds the ability to define schema with the `@graph` key that contains an array of schema types.

It does it by adding a `GraphContainer` class that receives an array of properties and parses them by calling `to_json_struct` on each one of them.